### PR TITLE
Clean up install-uzbl-browser makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ install-uzbl-browser: install-dirs install-uzbl-core install-event-manager
 	#sed 's#@PREFIX@#$(PREFIX)#g' < README.event-manager.md > README.event-manager.md
 	#$(INSTALL) -m644 README.event-manager.md $(DOCDIR)/README.event-manager.md
 	cp -rv examples $(INSTALLDIR)/share/uzbl/examples
-	chmod 755 $(INSTALLDIR)/share/uzbl/examples/data/scripts/*
+	chmod 755 $(INSTALLDIR)/share/uzbl/examples/data/scripts/*.sh $(INSTALLDIR)/share/uzbl/examples/data/scripts/*.py
 	$(INSTALL) -m644 uzbl.desktop $(INSTALLDIR)/share/applications/uzbl.desktop
 
 install-uzbl-tabbed: install-dirs


### PR DESCRIPTION
First of all the `@PREFIX@` in the uzbl-browser.in and uzbl.desktop.in files is already repleaced by the makefile rule `bin/uzbl-browser` and `uzbl.desktop` so there is no need to do that twice. In addition to that the mode of the examples scripts doesn't need to be modified after they have been installed to `$(INSTALLDIR)/share/uzbl/examples/data/scripts/*` since 755 is already the mode of the relevant examples scripts in the repo.
